### PR TITLE
Added UserContextFactory to GraphQLUploadOptions

### DIFF
--- a/src/GraphQL.Upload.AspNetCore/GraphQLUploadMiddleware.cs
+++ b/src/GraphQL.Upload.AspNetCore/GraphQLUploadMiddleware.cs
@@ -90,7 +90,8 @@ namespace GraphQL.Upload.AspNetCore
                     Schema = schema,
                     Query = request.Query,
                     OperationName = request.OperationName,
-                    Inputs = request.GetInputs()
+                    Inputs = request.GetInputs(),
+                    UserContext = _options.UserContextFactory?.Invoke(context)
                 }
             )));
 

--- a/src/GraphQL.Upload.AspNetCore/GraphQLUploadOptions.cs
+++ b/src/GraphQL.Upload.AspNetCore/GraphQLUploadOptions.cs
@@ -1,4 +1,7 @@
-﻿namespace GraphQL.Upload.AspNetCore
+﻿using System;
+using Microsoft.AspNetCore.Http;
+
+namespace GraphQL.Upload.AspNetCore
 {
     /// <summary>
     /// Options for <see cref="GraphQLUploadMiddleware{TSchema}"/>.
@@ -14,5 +17,10 @@
         /// The maximum allowed amount of files. Null indicates no limit at all.
         /// </summary>
         public long? MaximumFileCount { get; set; }
+
+        /// <summary>
+        /// Gets or sets the user context factory.
+        /// </summary>
+        public Func<HttpContext, object> UserContextFactory { get; set; }
     }
 }


### PR DESCRIPTION
Added a UserContextFactory to GraphQLUploadOptions as I need a way to access the user context in the resolvers.  Example usage:
```
app.UseGraphQLUpload<ISchema>("/graphql", options =>
{
      options.UserContextFactory = (httpContext) => new UserContext(httpContext);
});
```