### PR TITLE
UseGraphQLUpload: remove dependency on singleton schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ public void Configure(IApplicationBuilder app)
 }
 ```
 
-Register within your MySchema.cs.
+Register a `FormFileConverter` within your MySchema.cs.
 ```c#
 public class MySchema : Schema
 {

--- a/README.md
+++ b/README.md
@@ -29,6 +29,19 @@ public void Configure(IApplicationBuilder app)
 }
 ```
 
+Register within your MySchema.cs
+```c#
+public class MySchema : Schema
+{
+    public MySchema()
+    {
+        Query = new Query();
+        Mutation = new Mutation();
+        RegisterValueConverter(new FormFileConverter());
+    }
+}
+```
+
 Use the upload scalar in your resolvers. Files are exposed as `IFormFile`. 
 ```csharp
 Field<StringGraphType>(

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ public void Configure(IApplicationBuilder app)
 }
 ```
 
-Register within your MySchema.cs
+Register within your MySchema.cs.
 ```c#
 public class MySchema : Schema
 {

--- a/samples/FileUploadSample/SampleSchema.cs
+++ b/samples/FileUploadSample/SampleSchema.cs
@@ -15,6 +15,7 @@ namespace FileUploadSample
         {
             Query = resolver.Resolve<Query>();
             Mutation = resolver.Resolve<Mutation>();
+            RegisterValueConverter(new FormFileConverter());
         }
     }
 

--- a/src/GraphQL.Upload.AspNetCore/ApplicationBuilderExtensions.cs
+++ b/src/GraphQL.Upload.AspNetCore/ApplicationBuilderExtensions.cs
@@ -40,13 +40,6 @@ namespace Microsoft.AspNetCore.Builder
             if (options is null)
                 throw new ArgumentNullException(nameof(options));
 
-            var schema = (TSchema)builder.ApplicationServices.GetService(typeof(TSchema));
-
-            if (schema == null)
-                throw new ArgumentException($"No service type for {typeof(TSchema).FullName} registered.");
-
-            schema.RegisterValueConverter(new FormFileConverter());
-
             return builder.UseWhen(context => context.Request.Path.StartsWithSegments(path), branch => branch.UseMiddleware<GraphQLUploadMiddleware<ISchema>>(options));
         }
     }

--- a/tests/GraphQL.Upload.AspNetCore.Tests/TestSchema.cs
+++ b/tests/GraphQL.Upload.AspNetCore.Tests/TestSchema.cs
@@ -11,6 +11,7 @@ namespace GraphQL.Upload.AspNetCore.Tests
         {
             Query = new Query();
             Mutation = new Mutation();
+            RegisterValueConverter(new FormFileConverter());
         }
     }
 


### PR DESCRIPTION
This PR removes the hard dependency on schema being a Singleton and introduces the burden of ValueConverter registration to the schema itself. 
Fixes #2 