### PR TITLE
Upgrade to graphql-dotnet 4 and support for .NET 5

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,8 +14,8 @@
     </Choose>
 
     <PropertyGroup>
-        <GraphQLVersion>3.0.0</GraphQLVersion>
-        <GraphQLServerVersion>3.5.0-alpha0073</GraphQLServerVersion>
+        <GraphQLVersion>4.0.2</GraphQLVersion>
+        <GraphQLServerVersion>5.0.0</GraphQLServerVersion>
         <MicrosoftAspNetCoreHttpAbstractionsVersion>2.2.0</MicrosoftAspNetCoreHttpAbstractionsVersion>
         <MicrosoftAspNetCoreHttpFeaturesVersion>3.1.2</MicrosoftAspNetCoreHttpFeaturesVersion>
         <MicrosoftExtensionsLoggingVersion>3.1.2</MicrosoftExtensionsLoggingVersion>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,8 +1,17 @@
 <Project>
 
-    <PropertyGroup>
-        <IsNetCore3OnwardsTarget>$(TargetFramework.StartsWith('netcoreapp3.'))</IsNetCore3OnwardsTarget>
-    </PropertyGroup>
+    <Choose>
+        <When Condition="$(TargetFramework.StartsWith('netcoreapp3.')) Or $(TargetFramework.StartsWith('net5'))">
+            <PropertyGroup>
+                <IsNetCore3OnwardsTarget>True</IsNetCore3OnwardsTarget>
+            </PropertyGroup>
+        </When>
+        <Otherwise>
+            <PropertyGroup>
+                <IsNetCore3OnwardsTarget>False</IsNetCore3OnwardsTarget>
+            </PropertyGroup>
+        </Otherwise>
+    </Choose>
 
     <PropertyGroup>
         <GraphQLVersion>3.0.0</GraphQLVersion>

--- a/GraphQL.Upload.AspNetCore.sln
+++ b/GraphQL.Upload.AspNetCore.sln
@@ -37,6 +37,7 @@ Global
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{41D23D02-FD11-457D-A8BC-1EC7726E85B2} = {237BB3B8-77C3-4190-91F1-5616A7507679}
+		{2A45856C-FF34-47B8-BC5B-E037829ABCF9} = {CC98F604-7F80-4718-A307-7AA63FF55361}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {38A55A3C-5D48-44C3-85FE-9B5EAFCE67F8}

--- a/README.md
+++ b/README.md
@@ -32,19 +32,6 @@ public void Configure(IApplicationBuilder app)
 }
 ```
 
-Register a `FormFileConverter` within your MySchema.cs.
-```csharp
-public class MySchema : Schema
-{
-    public MySchema()
-    {
-        Query = new Query();
-        Mutation = new Mutation();
-        RegisterValueConverter(new FormFileConverter());
-    }
-}
-```
-
 Use the upload scalar in your resolvers. Files are exposed as `IFormFile`. 
 ```csharp
 Field<StringGraphType>(

--- a/samples/FileUploadSample/SampleSchema.cs
+++ b/samples/FileUploadSample/SampleSchema.cs
@@ -17,7 +17,6 @@ namespace FileUploadSample
         {
             Query = provider.GetRequiredService<Query>();
             Mutation = provider.GetRequiredService<Mutation>();
-            RegisterValueConverter(new FormFileConverter());
         }
     }
 

--- a/samples/FileUploadSample/Startup.cs
+++ b/samples/FileUploadSample/Startup.cs
@@ -1,8 +1,7 @@
 ﻿using GraphQL.Server;
-using GraphQL.Server.Ui.Playground;
 using GraphQL.Types;
+
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
@@ -20,11 +19,9 @@ namespace FileUploadSample
             services.AddSingleton<FileGraphType>();
 
             services.AddGraphQLUpload();
-            services.AddGraphQL(_ =>
-            {
-                _.ExposeExceptions = true;
-            })
-            .AddSystemTextJson();
+            services.AddGraphQL()
+                .AddErrorInfoProvider(opt => opt.ExposeExceptionStackTrace = true)
+                .AddSystemTextJson();
 
             services.AddCors();
         }
@@ -47,10 +44,7 @@ namespace FileUploadSample
             app.UseGraphQLUpload<ISchema>();
 
             app.UseGraphQL<ISchema>();
-            app.UseGraphQLPlayground(new GraphQLPlaygroundOptions
-            {
-                Path = "/"
-            });
+            app.UseGraphQLPlayground("/");
         }
     }
 }

--- a/src/GraphQL.Upload.AspNetCore/GraphQL.Upload.AspNetCore.csproj
+++ b/src/GraphQL.Upload.AspNetCore/GraphQL.Upload.AspNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netcoreapp3.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp3.0;netstandard2.0</TargetFrameworks>
     <Version>1.0.0</Version>
     <Authors>Jannik Lassahn</Authors>
     <Company />

--- a/tests/GraphQL.Upload.AspNetCore.Tests/GraphQL.Upload.AspNetCore.Tests.csproj
+++ b/tests/GraphQL.Upload.AspNetCore.Tests/GraphQL.Upload.AspNetCore.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/tests/GraphQL.Upload.AspNetCore.Tests/TestSchema.cs
+++ b/tests/GraphQL.Upload.AspNetCore.Tests/TestSchema.cs
@@ -11,12 +11,17 @@ namespace GraphQL.Upload.AspNetCore.Tests
         {
             Query = new Query();
             Mutation = new Mutation();
-            RegisterValueConverter(new FormFileConverter());
         }
     }
 
-    public class Query : ObjectGraphType
+    public sealed class Query : ObjectGraphType
     {
+        public Query()
+        {
+            Field<NonNullGraphType<BooleanGraphType>>()
+                .Name("dummy")
+                .Resolve(x => true);
+        }
     }
 
     public class Mutation : ObjectGraphType


### PR DESCRIPTION
This PR contains the following changes:

# Cosmetic

- Moved `GraphQL.Upload.AspNetCore` project to thje `src/` solution folder

# New

- Enabled .NET 5.0 builds

# Breaking

- Upgrade to GraphQL.NET 4.0.2 and GraphQL.Server.* 5.0.0
  - `GraphQL.Server.*` packages require at least GraphQL 4.0.2
- `UploadGraphType.ParseLiteral` follows the [documentation for custom scalars](https://graphql-dotnet.github.io/docs/getting-started/custom-scalars)
  - I left out the `Serialize` override, because the default implementation just calls `ParseValue`, which - in our case - just returns the input value
- `TestSchema` query requires at least one field

# Important

Merging this PR together with PR #19 results in uncompilable code. The reason for this is, that `GraphQL.Server.Transports.AspNetCore` 5.0.0 only supports `netcoreapp3.1` and `net5.0`.

In other words: The `netstandard2.0`, `netcoreapp2.1` and `netcoreapp3.0` target frameworks have to be removed from the projects `GraphQL.Upload.AspNetCore`, and `GraphQL.Upload.AspNetCore.Tests`.