### PR TITLE
Support for IUserContextBuilder

### DIFF
--- a/src/GraphQL.Upload.AspNetCore/GraphQL.Upload.AspNetCore.csproj
+++ b/src/GraphQL.Upload.AspNetCore/GraphQL.Upload.AspNetCore.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;netcoreapp3.0;netstandard2.0</TargetFrameworks>
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="GraphQL" Version="$(GraphQLVersion)" />
+    <PackageReference Include="GraphQL.Server.Transports.AspNetCore" Version="$(GraphQLServerVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="$(MicrosoftAspNetCoreHttpFeaturesVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggingVersion)" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="$(MicrosoftExtensionsOptionsVersion)" />

--- a/src/GraphQL.Upload.AspNetCore/GraphQLUploadOptions.cs
+++ b/src/GraphQL.Upload.AspNetCore/GraphQLUploadOptions.cs
@@ -22,6 +22,7 @@ namespace GraphQL.Upload.AspNetCore
         /// <summary>
         /// Gets or sets the user context factory.
         /// </summary>
+        [Obsolete("Register a service that implements IUserContextBuilder to create a user context.")]
         public Func<HttpContext, IDictionary<string, object>> UserContextFactory { get; set; }
     }
 }


### PR DESCRIPTION
- Additional reference to the `GraphQL.Server.Transports.AspNetCore` package
- UserContextFactory marked as obsolete
- A configured UserContextFactory takes precedence over a configured IUserContextBuilder

# Important

Merging this PR together with PR #18 results in uncompilable code. The reason for this is, that `GraphQL.Server.Transports.AspNetCore` 5.0.0 only supports `netcoreapp3.1` and `net5.0`.

In other words: The `netstandard2.0`, `netcoreapp2.1` and `netcoreapp3.0` target frameworks have to be removed from the projects `GraphQL.Upload.AspNetCore`, and `GraphQL.Upload.AspNetCore.Tests`.